### PR TITLE
qtwebbrowser: load initialUrl

### DIFF
--- a/src/qml/BrowserWindow.qml
+++ b/src/qml/BrowserWindow.qml
@@ -207,7 +207,7 @@ Item {
             navigation.webView = tab.webView
             var url = AppEngine.initialUrl
 
-            navigation.load();
+            navigation.load(url);
         }
         onCurrentIndexChanged: {
             if (!tabView.get(tabView.currentIndex))


### PR DESCRIPTION
fix regression of setting a initial url via argv.
Fixes: 60a8ef724c11 ("Clean up the application after integration for
b2qt")

Signed-off-by: Jan Remmet <j.remmet@phytec.de>